### PR TITLE
Closes #79 and #80

### DIFF
--- a/backend/lib/functional_vote/polls.ex
+++ b/backend/lib/functional_vote/polls.ex
@@ -80,7 +80,6 @@ defmodule FunctionalVote.Polls do
             where: r.poll_id == ^poll_id,
             select: {r.round, r.choice, r.votes}
     data = Repo.all(query)
-    IO.inspect(data)
     _tallies_by_count = Enum.group_by(data,
                                      fn {round, _, _} -> round end,
                                      fn {_, choice, votes} -> {choice, votes} end)
@@ -230,7 +229,7 @@ defmodule FunctionalVote.Polls do
     votes = Votes.get_votes(poll_id)
     if (map_size(votes) == 0) do
       IO.puts("[PollCtx] No votes in poll, returning empty tallies and winner")
-      calculated = %{tallies: nil, winner: nil}
+      calculated = %{tallies: [], winner: ""}
       Map.merge(poll, calculated) # RETURN ENDPOINT
     else
       {irv_tallies, winner} = instant_runoff(votes, poll_id)

--- a/backend/lib/functional_vote/votes.ex
+++ b/backend/lib/functional_vote/votes.ex
@@ -94,10 +94,10 @@ defmodule FunctionalVote.Votes do
   defp validate_integer_ranks(choices) do
     try do
       Enum.map(choices, fn {k, v} -> 
-                          # Maintain backwards compatibility if others want to submit ranks as ints represented as strings
-                          v = if is_integer(v), do: v, else: String.to_integer(v)
-                          {k, v}
-                        end)
+        # Maintain backwards compatibility if others want to submit ranks as ints represented as strings
+        v = if is_integer(v), do: v, else: String.to_integer(v)
+        {k, v}
+      end)
     rescue
       ArgumentError ->
         IO.puts("[VoteCtx] Received a vote with a non-integer rank")

--- a/backend/lib/functional_vote/votes.ex
+++ b/backend/lib/functional_vote/votes.ex
@@ -73,10 +73,12 @@ defmodule FunctionalVote.Votes do
           # No error
           IO.puts("[VoteCtx] Got #{map_size(choices)} choices")
           Enum.each choices, fn {k, v} ->
+            # Maintain backwards compatibility if others want to submit ranks as ints represented as strings
+            v = if is_integer(v), do: v, else: String.to_integer(v)
             choice_map = %{"poll_id" => poll_id,
                            "user_id" => user_id,
                            "choice"  => k,
-                           "rank"    => String.to_integer(v)}
+                           "rank"    => v}
             %Votes{}
             |> Votes.changeset(choice_map)
             |> Repo.insert() # RETURN ENDPOINT
@@ -91,7 +93,11 @@ defmodule FunctionalVote.Votes do
 
   defp validate_integer_ranks(choices) do
     try do
-      Enum.map(choices, fn {k, v} -> {k, String.to_integer(v)} end)
+      Enum.map(choices, fn {k, v} -> 
+                          # Maintain backwards compatibility if others want to submit ranks as ints represented as strings
+                          v = if is_integer(v), do: v, else: String.to_integer(v)
+                          {k, v}
+                        end)
     rescue
       ArgumentError ->
         IO.puts("[VoteCtx] Received a vote with a non-integer rank")

--- a/backend/lib/functional_vote_web/controllers/vote_controller.ex
+++ b/backend/lib/functional_vote_web/controllers/vote_controller.ex
@@ -17,7 +17,7 @@ defmodule FunctionalVoteWeb.VoteController do
     IO.puts("[VoteCtrl] Submit vote")
     case Votes.create_vote(vote_params) do
       :ok ->
-        {_, _, winner} = vote_params["poll_id"]
+        {_, winner} = vote_params["poll_id"]
                          |> Votes.get_votes()
                          |> Polls.instant_runoff(vote_params["poll_id"], true)
         if (winner === :error) do

--- a/backend/lib/functional_vote_web/views/poll_view.ex
+++ b/backend/lib/functional_vote_web/views/poll_view.ex
@@ -14,7 +14,6 @@ defmodule FunctionalVoteWeb.PollView do
     %{poll_id: poll.poll_id,
       title: poll.title,
       choices: poll.choices,
-      raw_tallies: poll.raw_tallies,
       tallies: poll.tallies,
       winner: poll.winner}
   end


### PR DESCRIPTION
- Accept ranks as integer inputs ( closes #80 )
- Return tallies as list instead of map (rounds listed in sequence) ( closes #79 )
- Note: choices within each round have no particular ordering, to be done in #96 
- Return empty list for tallies and empty string for winner instead of nil when there are no votes
