### PR TITLE
Closes #62 Error Handling

### DIFF
--- a/backend/lib/functional_vote/polls.ex
+++ b/backend/lib/functional_vote/polls.ex
@@ -255,10 +255,10 @@ defmodule FunctionalVote.Polls do
     poll_id = StringGenerator.poll_id_of_length(8)
     IO.inspect(poll_id)
     if (attrs["title"] !== nil and String.trim(attrs["title"]) !== "") do
+      attrs = Map.update!(attrs, "choices",
+                &Enum.filter(&1, fn choice -> String.trim(choice) !== "" end))
       if (attrs["choices"] === Enum.uniq(attrs["choices"])) do
-        attrs = Map.update!(attrs, "choices",
-                  &Enum.filter(&1, fn choice -> String.trim(choice) !== "" end))
-                |> Map.put_new("poll_id", poll_id)
+        attrs = Map.put_new(attrs, "poll_id", poll_id)
         %Poll{}
         |> Poll.changeset(attrs)
         |> Repo.insert()

--- a/backend/lib/functional_vote/votes.ex
+++ b/backend/lib/functional_vote/votes.ex
@@ -60,6 +60,9 @@ defmodule FunctionalVote.Votes do
       # Parse out "choices" and insert an entry for each choice and rank
       choices = attrs["choices"]
       cond do
+        validate_non_empty_choices(choices) == :empty_choices_error ->
+          # Received empty choices list
+          :empty_choices_error # RETURN ENDPOINT
         validate_integer_ranks(choices) == :non_integer_rank_error ->
           # Received a vote with a non-integer rank
           :non_integer_rank_error # RETURN ENDPOINT
@@ -88,6 +91,12 @@ defmodule FunctionalVote.Votes do
       # Poll we are voting for does not exist
       IO.puts("[VoteCtx] poll_id #{poll_id} does not exist!")
       :id_error # RETURN ENDPOINT
+    end
+  end
+
+  defp validate_non_empty_choices(choices) do
+    if (choices == nil) do
+      :empty_choices_error
     end
   end
 

--- a/backend/lib/functional_vote_web/controllers/vote_controller.ex
+++ b/backend/lib/functional_vote_web/controllers/vote_controller.ex
@@ -27,6 +27,8 @@ defmodule FunctionalVoteWeb.VoteController do
         end
       :id_error ->
         send_resp(conn, :unprocessable_entity, "Invalid poll ID")
+      :empty_choices_error ->
+        send_resp(conn, :unprocessable_entity, "Received no votes")
       :non_integer_rank_error ->
         send_resp(conn, :unprocessable_entity, "Received a vote with a non-integer rank")
       :available_choices_error ->


### PR DESCRIPTION
- Filter out duplicate empty choices (previously would return duplicate choice error)
- Handle case of empty choices on vote submission (previously unhandled 500 error)